### PR TITLE
add open route api key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ AZURE_OPENAI_API_KEY=your_api_key
 OPEN_AI_API_KEY=your_openai_api_key
 ```
 
-**OpenRoute API (fallback when OpenAI key is not available):**
+**OpenRouter API:**
 ```bash
-OPENROUTE_API_KEY=your_openroute_api_key
+OPENROUTER_API_KEY=your_openrouter_api_key
 ```
 
-**Note:** Nuggetizer will automatically fallback to OpenRoute API if no OpenAI API key is found. You can also explicitly use OpenRoute by passing the `openroute_api_key` parameter to the Nuggetizer constructor.
+**Note:** Nuggetizer supports multiple API providers. If both OpenAI and OpenRouter keys are available, OpenAI will be used by default. You can explicitly use OpenRouter by passing the `openrouter_api_key` parameter to the Nuggetizer constructor.
 
 ## 🚀 Quick Start
 
@@ -96,10 +96,10 @@ nuggetizer_mixed = Nuggetizer(
     assigner_model="gpt-4o"  # Model for nugget assignment
 )
 
-# Option 3: Using OpenRoute API (automatic fallback or explicit)
-nuggetizer_openroute = Nuggetizer(
-    model="gpt-4o-mini",  # Model supported by OpenRoute
-    openroute_api_key="your_openroute_api_key"  # Optional: explicit OpenRoute key
+# Option 3: Using OpenRouter API
+nuggetizer_openrouter = Nuggetizer(
+    model="gpt-4o-mini",  # Model supported by OpenRouter
+    openrouter_api_key="your_openrouter_api_key"  # Explicit OpenRouter key
 )
 
 # Create and score nuggets
@@ -125,17 +125,17 @@ You can also run a little more elaborate example with:
 python3 examples/e2e.py
 ```
 
-**Running with OpenRoute API:**
-If you don't have an OpenAI API key, you can use OpenRoute API by setting the environment variable:
+**Running with OpenRouter API:**
+You can use OpenRouter API by setting the environment variable:
 ```bash
-# Set OpenRoute API key in environment
-export OPENROUTE_API_KEY=your_openroute_api_key
+# Set OpenRouter API key in environment
+export OPENROUTER_API_KEY=your_openrouter_api_key
 python3 examples/e2e.py
 ```
 
-Or create a `.env` file with your OpenRoute API key:
+Or create a `.env` file with your OpenRouter API key:
 ```bash
-echo "OPENROUTE_API_KEY=your_openroute_api_key" > .env
+echo "OPENROUTER_API_KEY=your_openrouter_api_key" > .env
 python3 examples/e2e.py
 ```
 
@@ -145,10 +145,10 @@ We also provide an async version of the Nuggetizer class, `AsyncNuggetizer`, in 
 python3 examples/async_e2e.py
 ```
 
-**Running async example with OpenRoute API:**
+**Running async example with OpenRouter API:**
 ```bash
-# Set OpenRoute API key in environment
-export OPENROUTE_API_KEY=your_openroute_api_key
+# Set OpenRouter API key in environment
+export OPENROUTER_API_KEY=your_openrouter_api_key
 python3 examples/async_e2e.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,26 @@ pip install -e .
 
 ### Environment Setup
 
-Create a `.env` file with your OpenAI credentials. For Azure OpenAI (default for GPT models):
+Create a `.env` file with your API credentials. Nuggetizer supports multiple API providers:
 
+**Azure OpenAI (default for GPT models):**
 ```bash
 AZURE_OPENAI_API_BASE=your_azure_endpoint
 AZURE_OPENAI_API_VERSION=your_api_version
 AZURE_OPENAI_API_KEY=your_api_key
 ```
 
-Or for OpenAI API:
-
+**OpenAI API:**
 ```bash
 OPEN_AI_API_KEY=your_openai_api_key
 ```
+
+**OpenRoute API (fallback when OpenAI key is not available):**
+```bash
+OPENROUTE_API_KEY=your_openroute_api_key
+```
+
+**Note:** Nuggetizer will automatically fallback to OpenRoute API if no OpenAI API key is found. You can also explicitly use OpenRoute by passing the `openroute_api_key` parameter to the Nuggetizer constructor.
 
 ## 🚀 Quick Start
 
@@ -89,6 +96,12 @@ nuggetizer_mixed = Nuggetizer(
     assigner_model="gpt-4o"  # Model for nugget assignment
 )
 
+# Option 3: Using OpenRoute API (automatic fallback or explicit)
+nuggetizer_openroute = Nuggetizer(
+    model="gpt-4o-mini",  # Model supported by OpenRoute
+    openroute_api_key="your_openroute_api_key"  # Optional: explicit OpenRoute key
+)
+
 # Create and score nuggets
 scored_nuggets = nuggetizer.create(request)
 
@@ -112,9 +125,30 @@ You can also run a little more elaborate example with:
 python3 examples/e2e.py
 ```
 
+**Running with OpenRoute API:**
+If you don't have an OpenAI API key, you can use OpenRoute API by setting the environment variable:
+```bash
+# Set OpenRoute API key in environment
+export OPENROUTE_API_KEY=your_openroute_api_key
+python3 examples/e2e.py
+```
+
+Or create a `.env` file with your OpenRoute API key:
+```bash
+echo "OPENROUTE_API_KEY=your_openroute_api_key" > .env
+python3 examples/e2e.py
+```
+
 We also provide an async version of the Nuggetizer class, `AsyncNuggetizer`, in `src/nuggetizer/models/async_nuggetizer.py`. To run this example, use:
 
 ```bash
+python3 examples/async_e2e.py
+```
+
+**Running async example with OpenRoute API:**
+```bash
+# Set OpenRoute API key in environment
+export OPENROUTE_API_KEY=your_openroute_api_key
 python3 examples/async_e2e.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ OPEN_AI_API_KEY=your_openai_api_key
 OPENROUTER_API_KEY=your_openrouter_api_key
 ```
 
-**Note:** Nuggetizer supports multiple API providers. If both OpenAI and OpenRouter keys are available, OpenAI will be used by default. You can explicitly use OpenRouter by passing the `openrouter_api_key` parameter to the Nuggetizer constructor.
+**Note:** Nuggetizer supports multiple API providers. If both OpenAI and OpenRouter keys are available, OpenAI will be used by default. You can explicitly use OpenRouter by passing the `use_openrouter=True` parameter to the Nuggetizer constructor or using the `--use_openrouter` flag in the examples.
 
 ## 🚀 Quick Start
 
@@ -96,10 +96,16 @@ nuggetizer_mixed = Nuggetizer(
     assigner_model="gpt-4o"  # Model for nugget assignment
 )
 
-# Option 3: Using OpenRouter API
+# Option 3: Using OpenRouter API (supports multiple providers)
 nuggetizer_openrouter = Nuggetizer(
-    model="gpt-4o-mini",  # Model supported by OpenRouter
-    openrouter_api_key="your_openrouter_api_key"  # Explicit OpenRouter key
+    model="x-ai/grok-4-fast:free",  # Grok model via OpenRouter
+    use_openrouter=True  # Explicitly use OpenRouter
+)
+
+# Option 4: Other OpenRouter models
+nuggetizer_claude = Nuggetizer(
+    model="anthropic/claude-3.5-sonnet",  # Claude via OpenRouter
+    use_openrouter=True  # Explicitly use OpenRouter
 )
 
 # Create and score nuggets
@@ -126,17 +132,25 @@ python3 examples/e2e.py
 ```
 
 **Running with OpenRouter API:**
-You can use OpenRouter API by setting the environment variable:
+You can use OpenRouter API to access multiple model providers:
 ```bash
 # Set OpenRouter API key in environment
 export OPENROUTER_API_KEY=your_openrouter_api_key
-python3 examples/e2e.py
+
+# Use Grok model (free tier) with OpenRouter
+python3 examples/e2e.py --model "x-ai/grok-4-fast:free" --use_openrouter
+
+# Use Claude model with OpenRouter
+python3 examples/e2e.py --model "anthropic/claude-3.5-sonnet" --use_openrouter
+
+# Use OpenAI models via OpenRouter
+python3 examples/e2e.py --model "openai/gpt-4o-mini" --use_openrouter
 ```
 
 Or create a `.env` file with your OpenRouter API key:
 ```bash
 echo "OPENROUTER_API_KEY=your_openrouter_api_key" > .env
-python3 examples/e2e.py
+python3 examples/e2e.py --model "x-ai/grok-4-fast:free" --use_openrouter
 ```
 
 We also provide an async version of the Nuggetizer class, `AsyncNuggetizer`, in `src/nuggetizer/models/async_nuggetizer.py`. To run this example, use:
@@ -149,7 +163,12 @@ python3 examples/async_e2e.py
 ```bash
 # Set OpenRouter API key in environment
 export OPENROUTER_API_KEY=your_openrouter_api_key
-python3 examples/async_e2e.py
+
+# Use Grok model (free tier) with OpenRouter
+python3 examples/async_e2e.py --model "x-ai/grok-4-fast:free" --use_openrouter
+
+# Use Claude model with OpenRouter
+python3 examples/async_e2e.py --model "anthropic/claude-3.5-sonnet" --use_openrouter
 ```
 
 ## 🛠️ Components

--- a/examples/async_e2e.py
+++ b/examples/async_e2e.py
@@ -104,7 +104,7 @@ Python's simplicity, versatility, vast ecosystem, and strong community support m
     return Request(query=query, documents=documents)
 
 
-async def process_request(request: Request, model: str, use_azure_openai: bool, log_level: int) -> None:
+async def process_request(request: Request, model: str, use_azure_openai: bool, use_openrouter: bool, log_level: int) -> None:
     """Process a request through the nuggetizer pipeline."""
     start_time = time.time()
     
@@ -113,7 +113,7 @@ async def process_request(request: Request, model: str, use_azure_openai: bool, 
     
     # Option 1: Single model for all components
     nuggetizer1 = AsyncNuggetizer(model=model, use_azure_openai=use_azure_openai,
-                                  log_level=log_level)
+                                  use_openrouter=use_openrouter, log_level=log_level)
     
     # Option 2: Different models for each component
     # nuggetizer2 = AsyncNuggetizer(
@@ -193,6 +193,7 @@ async def main():
     """Run the async e2e example."""
     parser = argparse.ArgumentParser(description='Run the async e2e example')
     parser.add_argument('--use_azure_openai', action='store_true', help='Use Azure OpenAI')
+    parser.add_argument('--use_openrouter', action='store_true', help='Use OpenRouter API')
     parser.add_argument('--model', type=str, default="gpt-4o", help='Model to use')
     parser.add_argument('--log_level', type=int, default=0, help='Log level')
     args = parser.parse_args()
@@ -201,7 +202,7 @@ async def main():
     print(f"Using model: {args.model}")
     
     request = create_sample_request()
-    await process_request(request, args.model, args.use_azure_openai, args.log_level)
+    await process_request(request, args.model, args.use_azure_openai, args.use_openrouter, args.log_level)
     print("\n✨ Example completed!")
 
 

--- a/examples/e2e.py
+++ b/examples/e2e.py
@@ -103,7 +103,7 @@ Python's simplicity, versatility, vast ecosystem, and strong community support m
     return Request(query=query, documents=documents)
 
 
-def process_request(request: Request, model: str, use_azure_openai: bool, log_level: int) -> None:
+def process_request(request: Request, model: str, use_azure_openai: bool, use_openrouter: bool, log_level: int) -> None:
     """Process a request through the nuggetizer pipeline."""
     start_time = time.time()
     
@@ -111,7 +111,7 @@ def process_request(request: Request, model: str, use_azure_openai: bool, log_le
     # Initialize components - API keys and Azure config are loaded automatically
     
     # Option 1: Single model for all components
-    nuggetizer1 = Nuggetizer(model=model, use_azure_openai=use_azure_openai, log_level=log_level)
+    nuggetizer1 = Nuggetizer(model=model, use_azure_openai=use_azure_openai, use_openrouter=use_openrouter, log_level=log_level)
     
     # Option 2: Different models for each component
     # nuggetizer2 = Nuggetizer(
@@ -182,6 +182,7 @@ def main():
     """Run the e2e example."""
     parser = argparse.ArgumentParser(description='Run the e2e example')
     parser.add_argument('--use_azure_openai', action='store_true', help='Use Azure OpenAI')
+    parser.add_argument('--use_openrouter', action='store_true', help='Use OpenRouter API')
     parser.add_argument('--model', type=str, default="gpt-4o", help='Model to use')
     parser.add_argument('--log_level', type=int, default=0, help='Log level')
     args = parser.parse_args()
@@ -189,7 +190,7 @@ def main():
     print("🔧 Starting E2E Nuggetizer Example...")
     print(f"Using model: {args.model}")
     request = create_sample_request()
-    process_request(request, args.model, args.use_azure_openai, args.log_level)
+    process_request(request, args.model, args.use_azure_openai, args.use_openrouter, args.log_level)
     print("\n✨ Example completed!")
 
 

--- a/src/nuggetizer/core/async_llm.py
+++ b/src/nuggetizer/core/async_llm.py
@@ -15,6 +15,7 @@ class AsyncLLMHandler:
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         use_azure_openai: bool = False,
+        use_openrouter: bool = False,
         openrouter_api_key: Optional[str] = None,
     ):
         self.model = model
@@ -30,18 +31,28 @@ class AsyncLLMHandler:
         else:
             # Check for explicit API keys first, then environment variables
             if api_keys is None:
-                # Try OpenAI API key first
-                openai_key = get_openai_api_key()
-                if openai_key is not None:
-                    api_keys = openai_key
-                    api_type = "openai"
-                else:
-                    # Try OpenRouter API key
+                if use_openrouter:
+                    # Use OpenRouter API
                     openrouter_key = openrouter_api_key or get_openrouter_api_key()
                     if openrouter_key is not None:
                         api_keys = openrouter_key
                         api_base = "https://openrouter.ai/api/v1"
                         api_type = "openrouter"
+                    else:
+                        raise ValueError("use_openrouter=True but no OpenRouter API key found")
+                else:
+                    # Try OpenAI API key first, then OpenRouter as fallback
+                    openai_key = get_openai_api_key()
+                    if openai_key is not None:
+                        api_keys = openai_key
+                        api_type = "openai"
+                    else:
+                        # Try OpenRouter API key as fallback
+                        openrouter_key = openrouter_api_key or get_openrouter_api_key()
+                        if openrouter_key is not None:
+                            api_keys = openrouter_key
+                            api_base = "https://openrouter.ai/api/v1"
+                            api_type = "openrouter"
             else:
                 # Use provided API keys with OpenAI by default
                 api_type = "openai"

--- a/src/nuggetizer/core/async_llm.py
+++ b/src/nuggetizer/core/async_llm.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union, Tuple
 import tiktoken
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 
-from ..utils.api import get_azure_openai_args, get_openai_api_key, get_openroute_api_key
+from ..utils.api import get_azure_openai_args, get_openai_api_key, get_openrouter_api_key
 
 class AsyncLLMHandler:
     def __init__(
@@ -15,7 +15,7 @@ class AsyncLLMHandler:
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         use_azure_openai: bool = False,
-        openroute_api_key: Optional[str] = None,
+        openrouter_api_key: Optional[str] = None,
     ):
         self.model = model
         self.context_size = context_size
@@ -28,15 +28,33 @@ class AsyncLLMHandler:
             api_version = azure_args.get("api_version")
             api_keys = azure_args.get("api_key", api_keys) or get_openai_api_key()
         else:
-            api_type = "openai"
-            # Try OpenAI API key first, fallback to OpenRoute if not available
-            api_keys = api_keys or get_openai_api_key()
+            # Check for explicit API keys first, then environment variables
             if api_keys is None:
-                openroute_key = openroute_api_key or get_openroute_api_key()
-                if openroute_key is not None:
-                    api_keys = openroute_key
-                    api_base = "https://openrouter.ai/api/v1"
-                    api_type = "openrouter"
+                # Try OpenAI API key first
+                openai_key = get_openai_api_key()
+                if openai_key is not None:
+                    api_keys = openai_key
+                    api_type = "openai"
+                else:
+                    # Try OpenRouter API key
+                    openrouter_key = openrouter_api_key or get_openrouter_api_key()
+                    if openrouter_key is not None:
+                        api_keys = openrouter_key
+                        api_base = "https://openrouter.ai/api/v1"
+                        api_type = "openrouter"
+            else:
+                # Use provided API keys with OpenAI by default
+                api_type = "openai"
+        # Ensure we have a valid API type and keys
+        if api_type is None or api_keys is None:
+            raise ValueError(
+                "No valid API key found. Please provide either:\n"
+                "1. OpenAI API key (OPEN_AI_API_KEY environment variable)\n"
+                "2. OpenRouter API key (OPENROUTER_API_KEY environment variable)\n"
+                "3. Azure OpenAI credentials (AZURE_OPENAI_API_KEY, etc.)\n"
+                "4. Pass api_keys parameter directly to Nuggetizer constructor"
+            )
+        
         self.api_keys = [api_keys] if isinstance(api_keys, str) else api_keys
         self.current_key_idx = 0
         self.client = self._initialize_client(api_type, api_base, api_version)

--- a/src/nuggetizer/core/llm.py
+++ b/src/nuggetizer/core/llm.py
@@ -14,6 +14,7 @@ class LLMHandler:
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         use_azure_openai: bool = False,
+        use_openrouter: bool = False,
         openrouter_api_key: Optional[str] = None,
     ):
         self.model = model
@@ -29,18 +30,28 @@ class LLMHandler:
         else:
             # Check for explicit API keys first, then environment variables
             if api_keys is None:
-                # Try OpenAI API key first
-                openai_key = get_openai_api_key()
-                if openai_key is not None:
-                    api_keys = openai_key
-                    api_type = "openai"
-                else:
-                    # Try OpenRouter API key
+                if use_openrouter:
+                    # Use OpenRouter API
                     openrouter_key = openrouter_api_key or get_openrouter_api_key()
                     if openrouter_key is not None:
                         api_keys = openrouter_key
                         api_base = "https://openrouter.ai/api/v1"
                         api_type = "openrouter"
+                    else:
+                        raise ValueError("use_openrouter=True but no OpenRouter API key found")
+                else:
+                    # Try OpenAI API key first, then OpenRouter as fallback
+                    openai_key = get_openai_api_key()
+                    if openai_key is not None:
+                        api_keys = openai_key
+                        api_type = "openai"
+                    else:
+                        # Try OpenRouter API key as fallback
+                        openrouter_key = openrouter_api_key or get_openrouter_api_key()
+                        if openrouter_key is not None:
+                            api_keys = openrouter_key
+                            api_base = "https://openrouter.ai/api/v1"
+                            api_type = "openrouter"
             else:
                 # Use provided API keys with OpenAI by default
                 api_type = "openai"

--- a/src/nuggetizer/core/llm.py
+++ b/src/nuggetizer/core/llm.py
@@ -2,7 +2,7 @@ import time
 from typing import Dict, List, Optional, Union, Tuple
 import tiktoken
 from openai import AzureOpenAI, OpenAI
-from ..utils.api import get_azure_openai_args, get_openai_api_key
+from ..utils.api import get_azure_openai_args, get_openai_api_key, get_openroute_api_key
 
 class LLMHandler:
     def __init__(
@@ -14,6 +14,7 @@ class LLMHandler:
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         use_azure_openai: bool = False,
+        openroute_api_key: Optional[str] = None,
     ):
         self.model = model
         self.context_size = context_size
@@ -27,7 +28,14 @@ class LLMHandler:
             api_keys = azure_args.get("api_key", api_keys) or get_openai_api_key()
         else:
             api_type = "openai"
+            # Try OpenAI API key first, fallback to OpenRoute if not available
             api_keys = api_keys or get_openai_api_key()
+            if api_keys is None:
+                openroute_key = openroute_api_key or get_openroute_api_key()
+                if openroute_key is not None:
+                    api_keys = openroute_key
+                    api_base = "https://openrouter.ai/api/v1"
+                    api_type = "openrouter"
         self.api_keys = [api_keys] if isinstance(api_keys, str) else api_keys
         self.current_key_idx = 0
         self.client = self._initialize_client(api_type, api_base, api_version)
@@ -41,6 +49,11 @@ class LLMHandler:
             )
         elif api_type == "openai":
             return OpenAI(api_key=self.api_keys[0])
+        elif api_type == "openrouter":
+            return OpenAI(
+                api_key=self.api_keys[0],
+                base_url=api_base
+            )
         else:
             raise ValueError(f"Invalid API type: {api_type}")
 

--- a/src/nuggetizer/core/llm.py
+++ b/src/nuggetizer/core/llm.py
@@ -2,7 +2,7 @@ import time
 from typing import Dict, List, Optional, Union, Tuple
 import tiktoken
 from openai import AzureOpenAI, OpenAI
-from ..utils.api import get_azure_openai_args, get_openai_api_key, get_openroute_api_key
+from ..utils.api import get_azure_openai_args, get_openai_api_key, get_openrouter_api_key
 
 class LLMHandler:
     def __init__(
@@ -14,7 +14,7 @@ class LLMHandler:
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
         use_azure_openai: bool = False,
-        openroute_api_key: Optional[str] = None,
+        openrouter_api_key: Optional[str] = None,
     ):
         self.model = model
         self.context_size = context_size
@@ -27,15 +27,33 @@ class LLMHandler:
             api_version = azure_args.get("api_version")
             api_keys = azure_args.get("api_key", api_keys) or get_openai_api_key()
         else:
-            api_type = "openai"
-            # Try OpenAI API key first, fallback to OpenRoute if not available
-            api_keys = api_keys or get_openai_api_key()
+            # Check for explicit API keys first, then environment variables
             if api_keys is None:
-                openroute_key = openroute_api_key or get_openroute_api_key()
-                if openroute_key is not None:
-                    api_keys = openroute_key
-                    api_base = "https://openrouter.ai/api/v1"
-                    api_type = "openrouter"
+                # Try OpenAI API key first
+                openai_key = get_openai_api_key()
+                if openai_key is not None:
+                    api_keys = openai_key
+                    api_type = "openai"
+                else:
+                    # Try OpenRouter API key
+                    openrouter_key = openrouter_api_key or get_openrouter_api_key()
+                    if openrouter_key is not None:
+                        api_keys = openrouter_key
+                        api_base = "https://openrouter.ai/api/v1"
+                        api_type = "openrouter"
+            else:
+                # Use provided API keys with OpenAI by default
+                api_type = "openai"
+        # Ensure we have a valid API type and keys
+        if api_type is None or api_keys is None:
+            raise ValueError(
+                "No valid API key found. Please provide either:\n"
+                "1. OpenAI API key (OPEN_AI_API_KEY environment variable)\n"
+                "2. OpenRouter API key (OPENROUTER_API_KEY environment variable)\n"
+                "3. Azure OpenAI credentials (AZURE_OPENAI_API_KEY, etc.)\n"
+                "4. Pass api_keys parameter directly to Nuggetizer constructor"
+            )
+        
         self.api_keys = [api_keys] if isinstance(api_keys, str) else api_keys
         self.current_key_idx = 0
         self.client = self._initialize_client(api_type, api_base, api_version)

--- a/src/nuggetizer/models/async_nuggetizer.py
+++ b/src/nuggetizer/models/async_nuggetizer.py
@@ -21,6 +21,7 @@ class AsyncNuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
+        openroute_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
         assigner_mode: NuggetAssignMode = NuggetAssignMode.SUPPORT_GRADE_3,
@@ -62,9 +63,9 @@ class AsyncNuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, **llm_kwargs)
-        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, **llm_kwargs)
-        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, **llm_kwargs)
+        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/async_nuggetizer.py
+++ b/src/nuggetizer/models/async_nuggetizer.py
@@ -21,7 +21,7 @@ class AsyncNuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
-        openroute_api_key: Optional[str] = None,
+        openrouter_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
         assigner_mode: NuggetAssignMode = NuggetAssignMode.SUPPORT_GRADE_3,
@@ -63,9 +63,9 @@ class AsyncNuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
-        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
-        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/async_nuggetizer.py
+++ b/src/nuggetizer/models/async_nuggetizer.py
@@ -64,9 +64,17 @@ class AsyncNuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        # Common LLM configuration shared across all handlers
+        llm_config = {
+            'api_keys': api_keys,
+            'use_openrouter': use_openrouter,
+            'openrouter_api_key': openrouter_api_key,
+            **llm_kwargs,
+        }
+
+        self.creator_llm = AsyncLLMHandler(creator_model, **llm_config)
+        self.scorer_llm = AsyncLLMHandler(scorer_model, **llm_config)
+        self.assigner_llm = AsyncLLMHandler(assigner_model, **llm_config)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/async_nuggetizer.py
+++ b/src/nuggetizer/models/async_nuggetizer.py
@@ -21,6 +21,7 @@ class AsyncNuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
+        use_openrouter: bool = False,
         openrouter_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
@@ -63,9 +64,9 @@ class AsyncNuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.creator_llm = AsyncLLMHandler(creator_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.scorer_llm = AsyncLLMHandler(scorer_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.assigner_llm = AsyncLLMHandler(assigner_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/nuggetizer.py
+++ b/src/nuggetizer/models/nuggetizer.py
@@ -63,9 +63,17 @@ class Nuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = LLMHandler(creator_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.scorer_llm = LLMHandler(scorer_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.assigner_llm = LLMHandler(assigner_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        # Common LLM configuration shared across all handlers
+        llm_config = {
+            'api_keys': api_keys,
+            'use_openrouter': use_openrouter,
+            'openrouter_api_key': openrouter_api_key,
+            **llm_kwargs,
+        }
+
+        self.creator_llm = LLMHandler(creator_model, **llm_config)
+        self.scorer_llm = LLMHandler(scorer_model, **llm_config)
+        self.assigner_llm = LLMHandler(assigner_model, **llm_config)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/nuggetizer.py
+++ b/src/nuggetizer/models/nuggetizer.py
@@ -20,7 +20,7 @@ class Nuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
-        openroute_api_key: Optional[str] = None,
+        openrouter_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
         assigner_mode: NuggetAssignMode = NuggetAssignMode.SUPPORT_GRADE_3,
@@ -62,9 +62,9 @@ class Nuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = LLMHandler(creator_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
-        self.scorer_llm = LLMHandler(scorer_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
-        self.assigner_llm = LLMHandler(assigner_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.creator_llm = LLMHandler(creator_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.scorer_llm = LLMHandler(scorer_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.assigner_llm = LLMHandler(assigner_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/nuggetizer.py
+++ b/src/nuggetizer/models/nuggetizer.py
@@ -20,6 +20,7 @@ class Nuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
+        openroute_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
         assigner_mode: NuggetAssignMode = NuggetAssignMode.SUPPORT_GRADE_3,
@@ -61,9 +62,9 @@ class Nuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = LLMHandler(creator_model, api_keys, **llm_kwargs)
-        self.scorer_llm = LLMHandler(scorer_model, api_keys, **llm_kwargs)
-        self.assigner_llm = LLMHandler(assigner_model, api_keys, **llm_kwargs)
+        self.creator_llm = LLMHandler(creator_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.scorer_llm = LLMHandler(scorer_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
+        self.assigner_llm = LLMHandler(assigner_model, api_keys, openroute_api_key=openroute_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/models/nuggetizer.py
+++ b/src/nuggetizer/models/nuggetizer.py
@@ -20,6 +20,7 @@ class Nuggetizer(BaseNuggetizer):
         scorer_model: Optional[str] = "gpt-4o",
         assigner_model: Optional[str] = "gpt-4o",
         api_keys: Optional[str] = None,
+        use_openrouter: bool = False,
         openrouter_api_key: Optional[str] = None,
         creator_mode: NuggetMode = NuggetMode.ATOMIC,
         scorer_mode: NuggetScoreMode = NuggetScoreMode.VITAL_OKAY,
@@ -62,9 +63,9 @@ class Nuggetizer(BaseNuggetizer):
         if assigner_model is None:
             assigner_model = "gpt-4o"
             
-        self.creator_llm = LLMHandler(creator_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.scorer_llm = LLMHandler(scorer_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
-        self.assigner_llm = LLMHandler(assigner_model, api_keys, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.creator_llm = LLMHandler(creator_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.scorer_llm = LLMHandler(scorer_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
+        self.assigner_llm = LLMHandler(assigner_model, api_keys, use_openrouter=use_openrouter, openrouter_api_key=openrouter_api_key, **llm_kwargs)
         
         # Initialize max nuggets
         if max_nuggets is not None:

--- a/src/nuggetizer/utils/api.py
+++ b/src/nuggetizer/utils/api.py
@@ -40,3 +40,9 @@ def get_anyscale_api_key() -> Optional[str]:
     load_dotenv(dotenv_path=".env.local")
     anyscale_api_key = os.getenv("ANYSCALE_API_KEY")
     return anyscale_api_key
+
+
+def get_openroute_api_key() -> Optional[str]:
+    load_dotenv(dotenv_path=".env")
+    openroute_api_key = os.getenv("OPENROUTE_API_KEY")
+    return openroute_api_key

--- a/src/nuggetizer/utils/api.py
+++ b/src/nuggetizer/utils/api.py
@@ -42,7 +42,7 @@ def get_anyscale_api_key() -> Optional[str]:
     return anyscale_api_key
 
 
-def get_openroute_api_key() -> Optional[str]:
+def get_openrouter_api_key() -> Optional[str]:
     load_dotenv(dotenv_path=".env")
-    openroute_api_key = os.getenv("OPENROUTE_API_KEY")
-    return openroute_api_key
+    openrouter_api_key = os.getenv("OPENROUTER_API_KEY")
+    return openrouter_api_key


### PR DESCRIPTION
It adds openRoute API key support, so we can use free openRoute API key to run experiments instead of a hard dependency on OpenAI API key to run experiments.
<img width="492" height="599" alt="Screenshot 2025-09-20 at 9 48 35 PM" src="https://github.com/user-attachments/assets/e342f73d-dc17-4825-95ae-d2f619cc98eb" />
