### PR TITLE
Allow to use Caching with sqlite

### DIFF
--- a/src/nuggetizer/core/cache.py
+++ b/src/nuggetizer/core/cache.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+class AttrDict(dict[str, Any]):
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+def cache_is_enabled():
+    return os.getenv("CACHE_DIR") is not None and os.getenv("CACHE_DIR")
+
+
+def create_cached_chat_completion(
+    client: Any, completion_params: dict[str, Any]
+) -> Any:
+    import sqlite3
+    cache_dir = os.getenv("CACHE_DIR")
+    if not cache_dir:
+        return client.chat.completions.create(**completion_params)
+
+    request_json = json.dumps(_to_jsonable(completion_params), sort_keys=True)
+    database_path = _get_database_path(cache_dir)
+    cache_key = _build_cache_key(
+        {
+            "model": completion_params.get("model"),
+            "request": request_json,
+        }
+    )
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS chat_completions_cache (
+                cache_key TEXT PRIMARY KEY,
+                request_json TEXT NOT NULL,
+                response_json TEXT NOT NULL
+            )
+            """
+        )
+        row = connection.execute(
+            "SELECT response_json FROM chat_completions_cache WHERE cache_key = ?",
+            (cache_key,),
+        ).fetchone()
+        if row is not None:
+            return _from_jsonable(json.loads(row[0]))
+
+        completion = client.chat.completions.create(**completion_params)
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO chat_completions_cache (
+                cache_key,
+                request_json,
+                response_json
+            ) VALUES (?, ?, ?)
+            """,
+            (
+                cache_key,
+                request_json,
+                json.dumps(_to_jsonable(completion), sort_keys=True),
+            ),
+        )
+        connection.commit()
+    return completion
+
+
+def _get_database_path(cache_dir: str) -> Path:
+    path = Path(cache_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    return path / "llm_cache.sqlite"
+
+
+def _build_cache_key(payload: dict[str, Any]) -> str:
+    normalized_payload = json.dumps(_to_jsonable(payload), sort_keys=True)
+    return hashlib.sha256(normalized_payload.encode("utf-8")).hexdigest()
+
+
+def _to_jsonable(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return _to_jsonable(value.model_dump(mode="json"))
+    if isinstance(value, dict):
+        return {key: _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_to_jsonable(item) for item in value]
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    if hasattr(value, "__dict__"):
+        return {key: _to_jsonable(item) for key, item in vars(value).items()}
+    return str(value)
+
+
+def _from_jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return AttrDict({key: _from_jsonable(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_from_jsonable(item) for item in value]
+    return value

--- a/src/nuggetizer/core/llm.py
+++ b/src/nuggetizer/core/llm.py
@@ -23,6 +23,7 @@ from ._llm_shared import (
     uses_responses_reasoning_api,
     validate_reasoning_effort,
 )
+from .cache import cache_is_enabled, create_cached_chat_completion
 
 
 class LLMHandler:
@@ -195,9 +196,14 @@ class LLMHandler:
                             "timeout": 60,
                         }
                         completion_params.update(self._build_reasoning_params())
-                    completion = self.client.chat.completions.create(
-                        **completion_params
-                    )
+                    if cache_is_enabled():
+                        completion = create_cached_chat_completion(
+                            self.client, completion_params
+                        )
+                    else:
+                        completion = self.client.chat.completions.create(
+                            **completion_params
+                        )
 
                     response = completion.choices[0].message.content
 

--- a/tests/test_llm_handlers.py
+++ b/tests/test_llm_handlers.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sqlite3
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -8,6 +11,7 @@ import pytest
 from openai import AsyncOpenAI, OpenAI
 
 from nuggetizer.core.async_llm import AsyncLLMHandler
+from nuggetizer.core.cache import _get_database_path
 from nuggetizer.core.llm import LLMHandler
 
 pytestmark = pytest.mark.core
@@ -353,3 +357,113 @@ def test_sync_reasoning_models_merge_system_and_user_messages() -> None:
         {"role": "user", "content": "system\nuser"},
         {"role": "assistant", "content": "assistant"},
     ]
+
+
+def test_sync_llm_handler_uses_sqlite_cache_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CACHE_DIR", str(tmp_path))
+    call_count = 0
+    handler = LLMHandler(model="gpt-4o", api_keys="test-key")
+
+    def fake_create(**kwargs: Any) -> Any:
+        nonlocal call_count
+        del kwargs
+        call_count += 1
+        return _fake_completion(SimpleNamespace(content="cached response"))
+
+    handler.client = cast(
+        OpenAI,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        ),
+    )
+
+    first_response, _, _, _ = handler.run([{"role": "user", "content": "prompt"}])
+    second_response, _, _, _ = handler.run([{"role": "user", "content": "prompt"}])
+
+    assert first_response == "cached response"
+    assert second_response == "cached response"
+    assert call_count == 1
+    assert _get_database_path(str(tmp_path)).exists()
+
+
+def test_sync_llm_handler_stores_request_json_in_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CACHE_DIR", str(tmp_path))
+    handler = LLMHandler(model="gpt-4o", api_keys="test-key")
+
+    def fake_create(**kwargs: Any) -> Any:
+        del kwargs
+        return _fake_completion(SimpleNamespace(content="cached response"))
+
+    handler.client = cast(
+        OpenAI,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        ),
+    )
+
+    handler.run([{"role": "user", "content": "prompt"}], temperature=0.25)
+
+    with sqlite3.connect(_get_database_path(str(tmp_path))) as connection:
+        row = connection.execute(
+            "SELECT request_json, response_json FROM chat_completions_cache"
+        ).fetchone()
+
+    assert row is not None
+    request_json, response_json = row
+    assert json.loads(request_json) == {
+        "max_completion_tokens": 4096,
+        "messages": [{"content": "prompt", "role": "user"}],
+        "model": "gpt-4o",
+        "temperature": 0.25,
+        "timeout": 60,
+    }
+    assert json.loads(response_json)["choices"][0]["message"]["content"] == (
+        "cached response"
+    )
+
+
+def test_sync_llm_handler_cache_key_distinguishes_models(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CACHE_DIR", str(tmp_path))
+    call_count = 0
+
+    def fake_create(**kwargs: Any) -> Any:
+        nonlocal call_count
+        call_count += 1
+        return _fake_completion(SimpleNamespace(content=kwargs["model"]))
+
+    first_handler = LLMHandler(model="gpt-4o", api_keys="test-key")
+    first_handler.client = cast(
+        OpenAI,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        ),
+    )
+    second_handler = LLMHandler(model="gpt-4.1", api_keys="test-key")
+    second_handler.client = cast(
+        OpenAI,
+        SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        ),
+    )
+
+    first_response, _, _, _ = first_handler.run([{"role": "user", "content": "prompt"}])
+    second_response, _, _, _ = second_handler.run(
+        [{"role": "user", "content": "prompt"}]
+    )
+
+    with sqlite3.connect(_get_database_path(str(tmp_path))) as connection:
+        row_count = connection.execute(
+            "SELECT COUNT(*) FROM chat_completions_cache"
+        ).fetchone()
+
+    assert first_response == "gpt-4o"
+    assert second_response == "gpt-4.1"
+    assert call_count == 2
+    assert row_count is not None
+    assert row_count[0] == 2


### PR DESCRIPTION
This is a small pull request (I did most coding with an LLM Agent, but I ensured that it works).

This pull request does not change the production behaviour when when the CACHE_DIR environment variable is not provided. When this environment variable is provided, an sqlite3 cache is used (so that the Nuggetizer can be re-executed from an existing cache and also can be re-started after an LLM downtime without having to re-run requests again).

Having this cache behaviour is helpful for TREC AutoJudge.

Best regards,

Maik